### PR TITLE
Fix recent player game log

### DIFF
--- a/slack-glickman/commands/game_logs.rb
+++ b/slack-glickman/commands/game_logs.rb
@@ -76,7 +76,7 @@ module SlackGlickman
           game_logs = const_get("Stattleship::#{sport.capitalize}GameLogs").fetch(params: query_params)
 
           if game_logs.size > 0
-            msg = game_logs.first.to_sentence
+            msg = game_logs.max_by { |log| log.game.timestamp }.to_sentence
             send_message client, data, ":#{statmoji}: #{msg}"
           else
             msg = 'Nothing to see here'


### PR DESCRIPTION
API game log response is unordered so the most recent game is now selected to return recent player game log.